### PR TITLE
fix: Encountered error while initiating handshake. InvalidCiphertextException

### DIFF
--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -230,7 +230,7 @@ func startExec(ctx context.Context, ecsClient *ecs.Client, opts ExecCommandOptio
 
 	var runtimeId string
 	for _, c := range describeResult.Tasks[0].Containers {
-		if c.Name != &opts.Cluster {
+		if aws.StringValue(c.Name) != opts.Container {
 			continue
 		}
 		runtimeId = *c.RuntimeId
@@ -257,7 +257,7 @@ func startExec(ctx context.Context, ecsClient *ecs.Client, opts ExecCommandOptio
 	}()
 	defer close(done)
 
-	err = util.ExecCommand(opts.Plugin, string(sess), opts.Region, "StartSession", opts.Profile, string(target), opts.Region)
+	err = util.ExecCommand(opts.Plugin, string(sess), opts.Region, "StartSession", opts.Profile, string(target), fmt.Sprintf("https://ecs.%s.amazonaws.com", opts.Region))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
例えば、以下にあるように監査ログで KMS を使った暗号化を有効にしていた場合に exec を利用する際
https://docs.aws.amazon.com/cdk/api/latest/docs/aws-ecs-readme.html#enabling-logging

以下のようなエラーが起きました

```
Encountered error while initiating handshake. Fetching data key failed: Unable to retrieve data key, Error when decrypting data key InvalidCiphertextException: 
```

調査したところ以下 2 点に問題があったようです

- runningId が取れていなかった
- 最後の引数 endpoint が単に region になっていた

上記に関して修正を行い Exec 出来る点を確認しました