### PR TITLE
Update golang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yukiarrr/ecsk
 
-go 1.20
+go 1.23
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2


### PR DESCRIPTION
https://go.dev/doc/devel/release#policy
>Each major Go release is supported until there are two newer major releases.

Latest two versions of golang are supported and latest version of golang is v1.23.
In other words, golang v1.20 is not supported.
Therefore, I update golang to v1.23.