### PR TITLE
Update actions/checkout and actions/setup-go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - name: Run GoReleaser


### PR DESCRIPTION
https://github.com/yukiarrr/ecsk/actions/runs/10452867593

```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v2, actions/setup-go@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

`actions/checkout` and `actions/setup-go` use deprecated Node.js version.
Therefore, I update those actions.