### PR TITLE
Match both curly quote and ASCII apostrophe in execute command agent retry check

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -395,7 +395,11 @@ func startRun(ctx context.Context, ecsClient *ecs.Client, opts RunCommandOptions
 				isExecuting = false
 
 				if err != nil {
-					if i < max-1 && strings.Contains(err.Error(), "the execute command agent isn’t running") {
+					errMsg := err.Error()
+					// AWS returns this error with either a curly apostrophe (U+2019) or
+					// an ASCII apostrophe (U+0027) depending on the environment; match both variants.
+					if i < max-1 && (strings.Contains(errMsg, "the execute command agent isn’t running") || // U+2019 curly
+						strings.Contains(errMsg, "the execute command agent isn't running")) { // U+0027 ASCII
 						select {
 						case <-ctx.Done():
 							return


### PR DESCRIPTION
Fixes #24

## 概要
[#24](https://github.com/yukiarrr/ecsk/issues/24) でご指摘いただいた通り、AWS の環境によって `the execute command agent isn't running` のアポストロフィが curly quote (`'`, U+2019) と ASCII (`'`) のどちらでも返ってくることが確認されました。

両方の表記にマッチするよう `strings.Contains` を OR 条件にしています。

## 動作確認
手元の環境（ASCII アポストロフィが返るケース）で、修正後リトライが正しく機能し、起動の遅いコンテナでも問題なく接続できることを確認しました。

---

<details>
<summary>English version</summary>

Fixes #24

## Summary
As discussed in [#24](https://github.com/yukiarrr/ecsk/issues/24), AWS appears to return the error message `the execute command agent isn't running` with either a curly quote (`'`, U+2019) or an ASCII apostrophe (`'`) depending on the environment.

This change updates the retry check to match both variants via an OR condition on `strings.Contains`.

## Verification
Verified locally (in an environment where AWS returns the ASCII apostrophe variant) that the retry loop now works as intended and slow-starting containers connect successfully.

</details>